### PR TITLE
GCP Integration

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -57,8 +57,11 @@ For instance with letsencrypt:
   * update `<YOUR_K8S_SECRET>` with previously generated secret
   * update `<YOUR_IMAGE>` with the GCR image used 
   * update the `SPRING_APPLICATION_JSON` value to add/update more Spring/Application related parameters
-* Update `k8s/ingress.tpl.yaml`
+* Edit `k8s/ingress.tpl.yaml`:
+  * Update `<YOUR_DOMAIN>` with the appropriate DNS
 * Apply the full config:
 
       kubectl apply -f k8s/
+* Wait...
+* Simulators will be available at `<YOUR_DOMAIN>/sim1`,...
 

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -1,0 +1,64 @@
+# GCP Configuration
+
+## Cloud Build
+
+[cloudbuild](cloudbuild) contains an example to build the dependencies, mocks
+and Docker image using Cloud Build.
+
+    cd cloudbuild
+    gcloud builds submit --config=cloudbuild.yaml  
+
+## Kubernetes
+
+[k8s](k8s) contains an example of deployment using 3 distinct simulators. They are
+available at `/sim`, `/sim2`, `/sim3`.
+
+**Requirements:**
+
+* VPC-native Kubernetes cluster
+* A domain name
+* SSL certificate for the domain
+* Service account for the application
+* Reserved IP (used to point the domain)
+
+### VPC-native
+
+...
+
+### SSL Cert
+
+For instance with letsencrypt:
+
+* Create the certificate
+
+      certbot certonly \
+          --preferred-challenges dns \
+          --manual \
+          -d <YOUR_DNS_DOMAIN>
+
+* Import into GCP
+
+      gcloud compute ssl-certificates create repbus-simulator \
+          --certificate=<PATH_TO>/cert.pem
+          --private-key=<PATH_TO>/privkey.pem
+
+### Service Account
+
+* Create a new key for the SA used by the application
+* Import the key into a Kubernetes secret:
+ 
+      kubectl create secret generic app-key-$(date +%s) \
+          --from-file=app-key.json \
+          --dry-run -o yaml | kubectl apply -f
+
+### Deployment
+
+* For each `k8s/mock-simX.tpl.yaml` files:
+  * update `<YOUR_K8S_SECRET>` with previously generated secret
+  * update `<YOUR_IMAGE>` with the GCR image used 
+  * update the `SPRING_APPLICATION_JSON` value to add/update more Spring/Application related parameters
+* Update `k8s/ingress.tpl.yaml`
+* Apply the full config:
+
+      kubectl apply -f k8s/
+

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -1,5 +1,7 @@
 # GCP Configuration
 
+Some docs/helpers/tools to build and deploy the simulator on GCP.
+
 ## Cloud Build
 
 [cloudbuild](cloudbuild) contains an example to build the dependencies, mocks
@@ -11,11 +13,11 @@ and Docker image using Cloud Build.
 ## Kubernetes
 
 [k8s](k8s) contains an example of deployment using 3 distinct simulators. They are
-available at `/sim`, `/sim2`, `/sim3`.
+available at `/sim1`, `/sim2`, `/sim3`.
 
 **Requirements:**
 
-* VPC-native Kubernetes cluster
+* **VPC-native** Kubernetes cluster
 * A domain name
 * SSL certificate for the domain
 * Service account for the application
@@ -27,7 +29,7 @@ available at `/sim`, `/sim2`, `/sim3`.
 
 ### SSL Cert
 
-For instance with letsencrypt:
+For instance with [Let’s Encrypt](https://letsencrypt.org/):
 
 * Create the certificate
 

--- a/gcp/cloudbuild/cloudbuild.yaml
+++ b/gcp/cloudbuild/cloudbuild.yaml
@@ -1,0 +1,56 @@
+## Full cloudbuild config.
+## Build all depdencieds, mocks, docker image and push to GCR
+steps:
+# build model
+- name: gcr.io/cloud-builders/git
+  args: ['clone', 'https://github.com/brownjasonj/com.reporting.mocks.model.git']
+- name: gcr.io/cloud-builders/mvn:3.5.0-jdk-8
+  entrypoint: 'mvn'
+  args: ['package', 'install']
+  dir: 'com.reporting.mocks.model'
+  volumes:
+  - name: 'm2'
+    path: '/root/.m2'
+# bulid interfaces
+- name: gcr.io/cloud-builders/git
+  args: ['clone', 'https://github.com/brownjasonj/com.reporting.mocks.interfaces.git']
+- name: gcr.io/cloud-builders/mvn:3.5.0-jdk-8
+  entrypoint: 'mvn'
+  args: ['package', 'install']
+  dir: com.reporting.mocks.interfaces
+  volumes:
+  - name: 'm2'
+    path: '/root/.m2'
+# build pubsub
+- name: gcr.io/cloud-builders/git
+  args: ['clone', 'https://github.com/brownjasonj/com.reporting.mocks.publishing.pubsub.git']
+- name: gcr.io/cloud-builders/mvn:3.5.0-jdk-8
+  entrypoint: 'mvn'
+  args: ['package', 'install']
+  dir: com.reporting.mocks.publishing.pubsub
+  volumes:
+  - name: 'm2'
+    path: '/root/.m2'
+# build bigtable
+- name: gcr.io/cloud-builders/git
+  args: ['clone', 'https://github.com/brownjasonj/com.reporting.mocks.persistence.bigtable.git']
+- name: gcr.io/cloud-builders/mvn:3.5.0-jdk-8
+  entrypoint: 'mvn'
+  args: ['package', 'install']
+  dir: com.reporting.mocks.persistence.bigtable
+  volumes:
+  - name: 'm2'
+    path: '/root/.m2'
+# final target
+- name: gcr.io/cloud-builders/git
+  args: ['clone', '-b', 'docker-fix', 'https://github.com/glinmac/com.reporting.mocks.git']
+- name: gcr.io/cloud-builders/mvn:3.5.0-jdk-8
+  entrypoint: 'mvn'
+  args: ['-Ddocker.image.prefix=${_GCR}/${PROJECT_ID}', 'package', 'dockerfile:build']
+  dir: com.reporting.mocks
+  volumes:
+  - name: 'm2'
+    path: '/root/.m2'
+images: ['eu.gcr.io/${PROJECT_ID}/com.reporting.mocks']
+substitutions:
+  _GCR: 'eu.gcr.io'

--- a/gcp/cloudbuild/cloudbuild.yaml
+++ b/gcp/cloudbuild/cloudbuild.yaml
@@ -43,7 +43,7 @@ steps:
     path: '/root/.m2'
 # final target
 - name: gcr.io/cloud-builders/git
-  args: ['clone', '-b', 'docker-fix', 'https://github.com/glinmac/com.reporting.mocks.git']
+  args: ['clone', 'https://github.com/brownjasonj/com.reporting.mocks.git']
 - name: gcr.io/cloud-builders/mvn:3.5.0-jdk-8
   entrypoint: 'mvn'
   args: ['-Ddocker.image.prefix=${_GCR}/${PROJECT_ID}', 'package', 'dockerfile:build']

--- a/gcp/k8s/ingress.tpl.yaml
+++ b/gcp/k8s/ingress.tpl.yaml
@@ -1,0 +1,38 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: ingress
+  annotations:
+    kubernetes.io/ingress.class: "gce"
+    kubernetes.io/ingress.global-static-ip-name: "repbus-simulator"
+    kubernetes.io/ingress.allow-http: "false"
+    ingress.gcp.kubernetes.io/pre-shared-cert: "repbus-simulator"
+spec:
+  rules:
+    - host: repbus-simulator.polaris.kaolin.dev
+      http:
+        paths:
+        - path: /sim1
+          backend:
+            serviceName: mocks-sim1
+            servicePort: 30010
+        - path: /sim1/*
+          backend:
+            serviceName: mocks-sim1
+            servicePort: 30010
+        - path: /sim2
+          backend:
+            serviceName: mocks-sim2
+            servicePort: 30020
+        - path: /sim2/*
+          backend:
+            serviceName: mocks-sim2
+            servicePort: 30020
+        - path: /sim3
+          backend:
+            serviceName: mocks-sim3
+            servicePort: 30030
+        - path: /sim3/*
+          backend:
+            serviceName: mocks-sim3
+            servicePort: 30030

--- a/gcp/k8s/ingress.tpl.yaml
+++ b/gcp/k8s/ingress.tpl.yaml
@@ -9,7 +9,7 @@ metadata:
     ingress.gcp.kubernetes.io/pre-shared-cert: "repbus-simulator"
 spec:
   rules:
-    - host: repbus-simulator.polaris.kaolin.dev
+    - host: <YOUR_DOMAIN>
       http:
         paths:
         - path: /sim1

--- a/gcp/k8s/mocks-sim1.tpl.yaml
+++ b/gcp/k8s/mocks-sim1.tpl.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: mocks-sim1
+  labels:
+    app: mocks-sim1
+spec:
+   replicas: 1
+   minReadySeconds: 60
+   selector:
+     matchLabels:
+       app: mocks-sim1
+   template:
+     metadata: 
+       labels:
+         app: mocks-sim1
+     spec:
+       terminationGracePeriodSeconds: 60
+       containers: 
+         - name: mocks-sim1
+           image: <YOUR_IMAGE>
+           readinessProbe:
+             httpGet:
+               path: /sim1/v2/api-docs
+               port: 30010
+           imagePullPolicy: Always
+           ports:
+             - containerPort: 30010
+           volumeMounts:
+             - name: google-cloud-key
+               mountPath: /usr/local/app/config
+               readOnly: true
+           env:
+             - name: GOOGLE_APPLICATION_CREDENTIALS
+               value: /usr/local/app/config/app-key.json
+             - name: SPRING_APPLICATION_JSON
+               value: '{"server": {"port": 30010, "servlet": { "contextPath": "/sim1"}}}'
+       volumes:
+         - name: google-cloud-key
+           secret:
+             secretName: <YOUR_K8S_SECRET>
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mocks-sim1
+  labels:
+    app: mocks-sim1
+  annotations:
+    beta.cloud.google.com/backend-config:
+      '{"default": "mocks-sim1"}'
+    cloud.google.com/neg:
+      '{"ingress": true}'
+spec:
+  selector:
+    app: mocks-sim1
+  ports:
+  - port: 30010
+    protocol: TCP
+  type: NodePort
+---
+apiVersion: cloud.google.com/v1beta1
+kind: BackendConfig
+metadata:
+  name: mocks-sim1
+  labels:
+    app: mocks-sim1
+spec:
+  iap:
+    enabled: false
+    oauthclientCredentials:
+      secretName: secret
+      includeProtocol: true
+      includeQueryString: false

--- a/gcp/k8s/mocks-sim2.tpl.yaml
+++ b/gcp/k8s/mocks-sim2.tpl.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: mocks-sim2
+  labels:
+    app: mocks-sim2
+spec:
+   replicas: 1
+   minReadySeconds: 60
+   selector:
+     matchLabels:
+       app: mocks-sim2
+   template:
+     metadata: 
+       labels:
+         app: mocks-sim2
+     spec:
+       terminationGracePeriodSeconds: 60
+       containers: 
+         - name: mocks-sim2
+           image: <YOUR_IMAGE>
+           readinessProbe:
+             httpGet:
+               path: /sim2/v2/api-docs
+               port: 30020
+           imagePullPolicy: Always
+           ports:
+             - containerPort: 30020
+           volumeMounts:
+             - name: google-cloud-key
+               mountPath: /usr/local/app/config
+               readOnly: true
+           env:
+             - name: GOOGLE_APPLICATION_CREDENTIALS
+               value: /usr/local/app/config/app-key.json
+             - name: SPRING_APPLICATION_JSON
+               value: '{"server": {"port": 30020, "servlet": { "contextPath": "/sim2"}}}'
+       volumes:
+         - name: google-cloud-key
+           secret:
+             secretName: <YOUR_K8S_SECRET>
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mocks-sim2
+  labels:
+    app: mocks-sim2
+  annotations:
+    beta.cloud.google.com/backend-config:
+      '{"default": "mocks-sim2"}'
+    cloud.google.com/neg:
+      '{"ingress": true}'
+spec:
+  selector:
+    app: mocks-sim2
+  ports:
+  - port: 30020
+    protocol: TCP
+  type: NodePort
+---
+apiVersion: cloud.google.com/v1beta1
+kind: BackendConfig
+metadata:
+  name: mocks-sim2
+  labels:
+    app: mocks-sim2
+spec:
+  iap:
+    enabled: false
+    oauthclientCredentials:
+      secretName: secret
+      includeProtocol: true
+      includeQueryString: false

--- a/gcp/k8s/mocks-sim3.tpl.yaml
+++ b/gcp/k8s/mocks-sim3.tpl.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: mocks-sim3
+  labels:
+    app: mocks-sim3
+spec:
+   replicas: 1
+   minReadySeconds: 60
+   selector:
+     matchLabels:
+       app: mocks-sim3
+   template:
+     metadata: 
+       labels:
+         app: mocks-sim3
+     spec:
+       terminationGracePeriodSeconds: 60
+       containers: 
+         - name: mocks-sim3
+           image: <YOUR_IMAGE>
+           readinessProbe:
+             httpGet:
+               path: /sim3/v2/api-docs
+               port: 30030
+           imagePullPolicy: Always
+           ports:
+             - containerPort: 30030
+           volumeMounts:
+             - name: google-cloud-key
+               mountPath: /usr/local/app/config
+               readOnly: true
+           env:
+             - name: GOOGLE_APPLICATION_CREDENTIALS
+               value: /usr/local/app/config/app-key.json
+             - name: SPRING_APPLICATION_JSON
+               value: '{"server": {"port": 30030, "servlet": { "contextPath": "/sim3"}}}'
+       volumes:
+         - name: google-cloud-key
+           secret:
+             secretName: <YOUR_K8S_SECRET>
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mocks-sim3
+  labels:
+    app: mocks-sim3
+  annotations:
+    beta.cloud.google.com/backend-config:
+      '{"default": "mocks-sim3"}'
+    cloud.google.com/neg:
+      '{"ingress": true}'
+spec:
+  selector:
+    app: mocks-sim3
+  ports:
+  - port: 30030
+    protocol: TCP
+  type: NodePort
+---
+apiVersion: cloud.google.com/v1beta1
+kind: BackendConfig
+metadata:
+  name: mocks-sim3
+  labels:
+    app: mocks-sim3
+spec:
+  iap:
+    enabled: false
+    oauthclientCredentials:
+      secretName: secret
+      includeProtocol: true
+      includeQueryString: false


### PR DESCRIPTION
* Cloud Build configuration to build the dependencies and Docker image on GCP
* Kubernetes configuration/templates to deploy simulator (3 simulators available at `<domain>/{sim1,sim2,sim3`})